### PR TITLE
Added support for handling logging event properties

### DIFF
--- a/source/log4net-loggly/LogglyFormatter.cs
+++ b/source/log4net-loggly/LogglyFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -71,6 +72,27 @@ namespace log4net.loggly
             if (_exceptionInfo != null)
             {
                 _loggingInfo.exception = _exceptionInfo;
+            }
+
+            //handling loggingevent properties
+            if (loggingEvent.Properties.Count > 0)
+            {
+                var properties = (IDictionary<string, object>)_loggingInfo;
+                foreach (DictionaryEntry property in loggingEvent.Properties)
+                {
+                    var fixedProperty = property.Value as IFixingRequired;
+                    object propertyValue;
+                    if (fixedProperty != null && fixedProperty.GetFixedObject() != null)
+                    {
+                        propertyValue = fixedProperty.GetFixedObject();
+                    }
+                    else
+                    {
+                        propertyValue = property.Value;
+                    }
+
+                    properties[(string)property.Key] = propertyValue;
+                }
             }
 
             //handling threadcontext properties


### PR DESCRIPTION
The LoggingEvent class comes with a dictionary for custom data much like the contexts. However, the scope for this dictionary is limited to the current event only and not the entire thread (which in some cases can be useful).

This PR implements support so the properties of the event show up in Loggly.